### PR TITLE
Fix breaking layout on mobile

### DIFF
--- a/pages/authority.vue
+++ b/pages/authority.vue
@@ -87,7 +87,7 @@
               Account address
             </div>
             <div
-              class="mt-4 text-lg font-medium text-grey-dark flex items-center"
+              class="mt-4 text-lg font-medium text-grey-dark flex items-center break-word"
             >
               {{ activeAccount.address }}
 


### PR DESCRIPTION
address breaks the block on mobile

Before
<img width="254" alt="image" src="https://user-images.githubusercontent.com/6696080/214968480-6450ea6e-1a15-42ca-a7e1-81845083267b.png">
After
<img width="173" alt="image" src="https://user-images.githubusercontent.com/6696080/214968553-af277d6f-fbd4-42b7-b572-1610565c528c.png">
